### PR TITLE
fix: Fixing case list API

### DIFF
--- a/tests/test_run_case_list.py
+++ b/tests/test_run_case_list.py
@@ -10,24 +10,32 @@ from varfish_cli.api import CONVERTER, models
 
 def test_run_case_list():
     url = "https://varfish.example.com"
-    address = "%s/variants/api/case/list/c3752df7-fa32-4784-8a48-e8f0e5a28790/" % url
+    address = "%s/cases/api/case/list/c3752df7-fa32-4784-8a48-e8f0e5a28790/" % url
     cases = CONVERTER.unstructure(
-        [
-            models.Case(
-                sodar_uuid=str(uuid.uuid4()),
-                date_created=datetime.datetime.now(),
-                date_modified=datetime.datetime.now(),
-                name="Case_Name",
-                index="index",
-                pedigree=[
-                    models.PedigreeMember(
-                        name="index", father="0", mother="0", sex=2, affected=2, has_gt_entries=True
-                    )
-                ],
-                num_small_vars=123,
-                num_svs=456,
-            )
-        ]
+        {
+            "next": None,
+            "results": [
+                models.Case(
+                    sodar_uuid=str(uuid.uuid4()),
+                    date_created=datetime.datetime.now(),
+                    date_modified=datetime.datetime.now(),
+                    name="Case_Name",
+                    index="index",
+                    pedigree=[
+                        models.PedigreeMember(
+                            name="index",
+                            father="0",
+                            mother="0",
+                            sex=2,
+                            affected=2,
+                            has_gt_entries=True,
+                        )
+                    ],
+                    num_small_vars=123,
+                    num_svs=456,
+                )
+            ],
+        }
     )
     with requests_mock.Mocker() as m:
         m.get(address, json=cases)

--- a/varfish_cli/api/case.py
+++ b/varfish_cli/api/case.py
@@ -142,7 +142,9 @@ def _paginated_request(endpoint, result_data=None, **kwargs):
         result_data += result_json["results"]
         return _paginated_request(result_json["next"], result_data=result_data, **kwargs)
     else:
-        raise RestApiCallException(f"Call against {endpoint} did not return paginated object: {result_json}")
+        raise RestApiCallException(
+            f"Call against {endpoint} did not return paginated object: {result_json}"
+        )
 
 
 def case_list(
@@ -156,7 +158,9 @@ def case_list(
     endpoint = "%s%s" % (server_url, ENDPOINT_CASE_LIST.format(project_uuid=project_uuid))
     logger.debug("Sending GET request to end point %s", endpoint)
     headers = {"Authorization": "Token %s" % api_token}
-    result = _paginated_request(endpoint, headers=headers, verify=verify_ssl, params={"page_size": 100})
+    result = _paginated_request(
+        endpoint, headers=headers, verify=verify_ssl, params={"page_size": 100}
+    )
     return CONVERTER.structure(result, typing.List[Case])
 
 

--- a/varfish_cli/api/models.py
+++ b/varfish_cli/api/models.py
@@ -50,9 +50,9 @@ class Case:
     #: Number of SVs in case.
     num_svs: typing.Optional[int]
     #: Cusom User Notes
-    notes: str
+    notes: typing.Optional[str] = None
     #: Status of case. Can be either "active" "closed-<solved|unsolved>" or "initial"
-    status: str
+    status: typing.Optional[str] = None
 
 
 class CaseImportState(Enum):

--- a/varfish_cli/api/models.py
+++ b/varfish_cli/api/models.py
@@ -49,6 +49,10 @@ class Case:
     num_small_vars: typing.Optional[int]
     #: Number of SVs in case.
     num_svs: typing.Optional[int]
+    #: Cusom User Notes
+    notes: str
+    #: Status of case. Can be either "active" "closed-<solved|unsolved>" or "initial"
+    status: str
 
 
 class CaseImportState(Enum):


### PR DESCRIPTION
Closes #27 

varfish-server had the case list API refactored into the cases app and the endpoint is now paginated. I extracted the requests call into a separate recursive function for getting all data from the endpoint and also took the freedom to add case model fields for completeness.