### PR TITLE
feat: add index option to case import

### DIFF
--- a/varfish_cli/cli/importer/__init__.py
+++ b/varfish_cli/cli/importer/__init__.py
@@ -138,7 +138,7 @@ def cli_caseimportinfo_create(
         typer.Option(
             "--index",
             help="Name of the index case in the pedigree, "
-            "defaults to the first member of the pedigree file.",
+            "defaults to the first affected member of the pedigree file.",
         ),
     ] = None,
 ):

--- a/varfish_cli/cli/importer/__init__.py
+++ b/varfish_cli/cli/importer/__init__.py
@@ -137,7 +137,8 @@ def cli_caseimportinfo_create(
         str,
         typer.Option(
             "--index",
-            help="Name of the index case in the pedigree, defaults to the first case.",
+            help="Name of the index case in the pedigree, "
+            "defaults to the first member of the pedigree file.",
         ),
     ] = None,
 ):

--- a/varfish_cli/cli/importer/__init__.py
+++ b/varfish_cli/cli/importer/__init__.py
@@ -133,6 +133,13 @@ def cli_caseimportinfo_create(
             help="The genome build (GRCh37/GRCh38) of this case, defaults to GRCh37.",
         ),
     ] = GenomeBuild.GRCH37.value,
+    index: typing.Annotated[
+        str,
+        typer.Option(
+            "--index",
+            help="Name of the index case in the pedigree, defaults to the first case.",
+        ),
+    ] = None,
 ):
     logger.info("Creating CaseImportInfo object...")
     common_options: CommonOptions = ctx.obj
@@ -145,6 +152,7 @@ def cli_caseimportinfo_create(
             force_fresh=force_fresh,
             resubmit=resubmit,
             project_uuid=project_uuid,
+            index=index,
         ),
         common_options=common_options,
     )

--- a/varfish_cli/cli/importer/create.py
+++ b/varfish_cli/cli/importer/create.py
@@ -279,6 +279,7 @@ class CaseImportOptions(pydantic.BaseModel):
     resubmit: bool
     force_fresh: bool
     case_name_suffix: str
+    index: typing.Union[str, None]
 
 
 class CaseImporter:
@@ -315,6 +316,7 @@ class CaseImporter:
 
         #: The pedigree members.
         self.pedigree: typing.List[PedigreeMember] = None
+        self.index: typing.Union[str, None] = None
 
     def _log_exception(self, e):
         logger.exception(e, exc_info=self.common_options.verbose)
@@ -519,7 +521,7 @@ class CaseImporter:
             return x
 
         name, self.pedigree = self._load_pedigree()
-        index = self.pedigree[0].name
+        index = self.index or self.pedigree[0].name
         name = strip_suffix(name)
 
         self._check_genotypes()

--- a/varfish_cli/cli/importer/create.py
+++ b/varfish_cli/cli/importer/create.py
@@ -521,6 +521,8 @@ class CaseImporter:
             return x
 
         name, self.pedigree = self._load_pedigree()
+        if self.index and self.index not in {member.name for member in self.pedigree}:
+            raise ValueError(f"Specified index case '{self.index}' not found in pedigree")
         index = self.index or self.pedigree[0].name
         name = strip_suffix(name)
 

--- a/varfish_cli/cli/importer/create.py
+++ b/varfish_cli/cli/importer/create.py
@@ -523,7 +523,11 @@ class CaseImporter:
         name, self.pedigree = self._load_pedigree()
         if self.index and self.index not in {member.name for member in self.pedigree}:
             raise ValueError(f"Specified index case '{self.index}' not found in pedigree")
-        index = self.index or self.pedigree[0].name
+        # use provided index member, first affected member or first general member as index
+        index = (
+            self.index
+            or next(filter(lambda m: m.affected == 2, self.pedigree), self.pedigree[0]).name
+        )
         name = strip_suffix(name)
 
         self._check_genotypes()

--- a/varfish_cli/cli/importer/create.py
+++ b/varfish_cli/cli/importer/create.py
@@ -316,7 +316,7 @@ class CaseImporter:
 
         #: The pedigree members.
         self.pedigree: typing.List[PedigreeMember] = None
-        self.index: typing.Union[str, None] = None
+        self.index: typing.Union[str, None] = options.index
 
     def _log_exception(self, e):
         logger.exception(e, exc_info=self.common_options.verbose)


### PR DESCRIPTION
Resolves #133 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line option for specifying the index case in the pedigree during case import.
	- Enhanced flexibility in the `caseimportinfo-create` command by allowing users to define the index case name.

- **Bug Fixes**
	- Improved logic for determining the index case, ensuring it defaults correctly when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->